### PR TITLE
Add support for custom ONTAP API port configuration

### DIFF
--- a/netapp_dataops_traditional/.gitignore
+++ b/netapp_dataops_traditional/.gitignore
@@ -1,3 +1,4 @@
 build
 netapp_dataops_traditional.egg-info
 dist
+*.pyc

--- a/netapp_dataops_traditional/docs/ontap_readme.md
+++ b/netapp_dataops_traditional/docs/ontap_readme.md
@@ -41,6 +41,8 @@ netapp_dataops_cli.py config
 
 Note: The toolkit requires an ONTAP account with API access. The toolkit will use this account to access the ONTAP API. NetApp recommends using an SVM-level account. Usage of a cluster admin account should be avoided for security reasons.
 
+Note: The toolkit supports custom port numbers for the ONTAP API connection. If not specified during configuration, the default port 443 (HTTPS) will be used. To use a custom port, specify it when creating the config file or add it to your existing `config.json` file as `"port": <port_number>`.
+
 > **Note: Keyring Service Configuration**
 > 
 > The toolkit stores ONTAP credentials securely using your system's keyring service. By default, it uses the service name `netapp:dataops:ontap` to store and retrieve credentials. 
@@ -50,6 +52,7 @@ Note: The toolkit requires an ONTAP account with API access. The toolkit will us
 ```sh
 netapp_dataops_cli.py config
 Enter ONTAP management LIF hostname or IP address (Recommendation: Use SVM management interface): 10.61.188.114
+Enter ONTAP API port number [443]: 8001
 Enter SVM (Storage VM) name: ailab1
 Enter SVM NFS data LIF hostname or IP address: 10.61.188.119
 Enter default volume type to use when creating new volumes (flexgroup/flexvol) [flexgroup]:        

--- a/netapp_dataops_traditional/netapp_dataops/netapp_dataops_cli.py
+++ b/netapp_dataops_traditional/netapp_dataops/netapp_dataops_cli.py
@@ -572,6 +572,16 @@ def createConfig(configDirPath: str = "~/.netapp_dataops", configFilename: str =
 
         # Prompt user to enter config details
         config["hostname"] = input("Enter ONTAP management LIF hostname or IP address (Recommendation: Use SVM management interface): ")
+        # Prompt user to enter port (optional, defaults to 443)
+        portInput = input("Enter ONTAP API port number [443]: ")
+        if portInput:
+            try:
+                config["port"] = int(portInput)
+            except ValueError:
+                logger.error("Invalid port number. Using default port 443.")
+                config["port"] = 443
+        else:
+            config["port"] = 443
         config["svm"] = input("Enter SVM (Storage VM) name: ")
         config["dataLif"] = input("Enter SVM NFS data LIF hostname or IP address: ")
 

--- a/netapp_dataops_traditional/netapp_dataops/traditional/__init__.py
+++ b/netapp_dataops_traditional/netapp_dataops/traditional/__init__.py
@@ -205,6 +205,8 @@ def _instantiate_connection(config: dict, connectionType: str = "ONTAP", print_o
             ontapClusterAdminUsername = config["username"]
             ontapClusterAdminPassword = config["password"]
             verifySSLCert = config["verifySSLCert"]
+            # Port is optional, default to 443 if not specified
+            ontapClusterPort = int(config.get("port", 443))
         except:
             if print_output:
                 _print_invalid_config_error()
@@ -220,7 +222,8 @@ def _instantiate_connection(config: dict, connectionType: str = "ONTAP", print_o
             host=ontapClusterMgmtHostname,
             username=ontapClusterAdminUsername,
             password=ontapClusterAdminPassword,
-            verify=verifySSLCert
+            verify=verifySSLCert,
+            port=ontapClusterPort
         )
 
     else:


### PR DESCRIPTION
Add optional port parameter to ONTAP connection setup, allowing users to specify custom API ports. Port defaults to 443 if not specified, maintaining full backward compatibility.

Changes:
- Add port parameter support to _instantiate_connection()
- Update CLI config creation to prompt for port (optional, defaults to 443)
- Update documentation with port configuration examples and notes

The port can be specified during config creation via interactive prompt or manually added to config.json as "port": <port_number>. This is particularly useful for environments where the ONTAP API is exposed on non-standard ports (e.g., port 8001 for MCP server usage).

## Use Cases
This change is particularly useful for:
- MCP server deployments where ONTAP API is exposed on custom ports (e.g., 8001)
- Development/testing environments with non-standard port configurations
- Network configurations requiring custom port mappings